### PR TITLE
Issue 33: multiple occurences of the same variable in KI_init

### DIFF
--- a/compiler/src/genKernel.ml
+++ b/compiler/src/genKernel.ml
@@ -451,7 +451,7 @@ let subs s =
   ; "KTRACE_INIT", (
       let pacc = coq_of_prog s "" [] s.init in
       mkstr "forall %s,\nKInvariant (mkst (%snil) [%snil] %s)"
-        (String.concat " " (prog_vars s.init))
+        (String.concat " " (uniq (prog_vars s.init)))
         (String.concat "" (List.map (fun c -> mkstr "%s :: " c) pacc.comps))
         pacc.trace_impl (* TODO should this use trace_spec ? *)
         (lkup_st_fields pacc.sstate s)

--- a/compiler/test/issue-33/kernel.krn
+++ b/compiler/test/issue-33/kernel.krn
@@ -1,5 +1,6 @@
 State {
-  main : chan;
+  # can't use main because we define something called main in Coq...
+  mainc : chan;
 }
 
 Components {
@@ -11,8 +12,8 @@ Messages {
 }
 
 Init {
-  main := spawn(Main);
-  send(main, M("Hello"));
+  mainc := spawn(Main);
+  send(mainc, M("Hello"));
 }
 
 Exchange(c) {

--- a/compiler/test/issue-33/kernel.krn
+++ b/compiler/test/issue-33/kernel.krn
@@ -1,0 +1,19 @@
+State {
+  main : chan;
+}
+
+Components {
+  Main "test.py";
+}
+
+Messages {
+  M(str);
+}
+
+Init {
+  main := spawn(Main);
+  send(main, M("Hello"));
+}
+
+Exchange(c) {
+}

--- a/compiler/test/issue-33/test.py
+++ b/compiler/test/issue-33/test.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python2.7
+
+import msg
+
+def main():
+  msg.init()
+  m = msg.recv()
+  print(m)
+
+main()


### PR DESCRIPTION
I suspect the same problem may happen elsewhere, this is a very quick fix.

Also, the test case raised the issue of not being able to name a state variable "main" as it conflicts later with the name "main" in Coq...
