### PR TITLE
Changes allowing shadowing and crazy chan manipulations

### DIFF
--- a/compiler/src/genKernel.ml
+++ b/compiler/src/genKernel.ml
@@ -64,8 +64,17 @@ type prog_acc =
   ; comps        : string list
   ; trace_impl   : string
   ; trace_spec   : string
+  (* sstate now contains mappings from a chan name occurence to the fresh name
+  of that same chan, in the case where is has been shadowed. The type could be
+  simplified as this does not deal anymore with other types of expressions,
+  whose let bindings are expanded after parsing, but I leveraged the existing
+  sstate code for simplicity. *)
   ; sstate       : sstate
+  (* scoped_chans keeps track of the channel names in scope, so that a binding
+  which shadows a scoped chan can be detected. *)
   ; scoped_chans : string list
+  (* fresh_vars keeps track of all the chan names introduced for disambiguating
+  shadowing, so that these can be quantified in places where it's needed. *)
   ; fresh_vars   : string list
   }
 

--- a/compiler/src/genKernel.ml
+++ b/compiler/src/genKernel.ml
@@ -44,8 +44,6 @@ let fresh_chan_id () =
   mkstr "c%d" (tock ())
 
 let extract_bound c fr =
-  Printf.printf "Looking for %s\n" c;
-  Printf.printf "in %s\n" (String.concat " * " fr);
   let s = mkstr "bound %s" c in
   let rec aux = function
     | [] -> raise Not_found

--- a/compiler/src/kernel.ml
+++ b/compiler/src/kernel.ml
@@ -47,15 +47,28 @@ type prog =
   | Nop
   | Seq of cmd * prog
 
+(* symbolic state
+ *
+ * Track current value of state var during a handler's symbolic execution.
+ * For example, after [a := a + 1], [a] is mapped to [a + 1].
+ *)
+type sstate = (id * expr) list
+
+(*
+  I'm sorry, this is quite hacky :(
+  sstate holds the final mapping
+*)
+type uprog = prog * sstate
+
 type cond_prog =
   { condition : when_cond
-  ; program   : prog
+  ; program   : uprog
   }
 
 let mk_cond_prog c r =
   { condition = c
   ; program   = r
-  } 
+  }
 
 type handler =
   { trigger  : msg_pat
@@ -92,7 +105,7 @@ type kernel =
   ; var_decls  : (id * typ) list
   ; components : (id * string) list
   ; msg_decls  : msg_decl list
-  ; init       : prog
+  ; init       : uprog
   ; exchange   : chan * ((component * handler list) list)
   ; props      : (id * prop) list
   }
@@ -102,7 +115,7 @@ let empty_kernel =
   ; var_decls  = []
   ; components = []
   ; msg_decls  = []
-  ; init       = Nop
+  ; init       = (Nop, [])
   ; exchange   = ("__xch__", [])
   ; props      = []
   }

--- a/compiler/src/kraken.ml
+++ b/compiler/src/kraken.ml
@@ -109,10 +109,55 @@ let parse_args () =
       ]
   end
 
+let desugar_let k =
+  let open Kernel in
+  let desugar p =
+    let rec desugar_aux bindings = function
+    | Nop -> (Nop, bindings)
+    | Seq (cmd, p) ->
+      match cmd with
+      | Assign (id, expr) ->
+        desugar_aux (GenKernel.set_var bindings id expr) p
+      | Send (c, msg) ->
+        let c = Gen.coq_of_expr (GenKernel.lkup_var bindings c) in
+        let msg = GenKernel.lkup_msg_expr bindings msg in
+        let (prog, bindings) = desugar_aux bindings p in
+        (Seq (Send(c, msg), prog), bindings)
+      | Call (res, f, arg) ->
+        let (prog, bindings) = desugar_aux bindings p in
+        (Seq (Call (res, f, arg), prog), bindings)
+      | Spawn (res, comp) ->
+        let (prog, bindings) = desugar_aux bindings p in
+        (Seq (Spawn (res, comp), prog), bindings)
+    in desugar_aux [] (fst p)
+  in
+  let open Kernel in
+  { k with
+    init = desugar k.init
+  ; exchange = (
+      let (c, chll) = k.exchange in
+      let chll =
+        List.map (fun (c, hl) ->
+          (c,
+            List.map (fun h ->
+              { h with responds =
+                List.map (fun cp ->
+                  { cp with program = desugar cp.program }
+                ) h.responds
+              }
+            ) hl
+          )
+        ) chll
+      in
+      (c, chll)
+    )
+  }
+
 let parse_kernel f =
   f |> readfile
     |> Lexing.from_string
     |> Parse.kernel Lex.token
+    |> desugar_let
 
 (* for catg: read template, rewrite with subs, write instance *)
 let instantiate catg (subs : (Str.regexp * string) list) =

--- a/compiler/src/parse.mly
+++ b/compiler/src/parse.mly
@@ -47,7 +47,7 @@ section :
   | MESSAGES LCURL msg_decls RCURL
     { _K := { !_K with msg_decls = $3 } }
   | INIT LCURL prog RCURL
-    { _K := { !_K with init = $3 } }
+    { _K := { !_K with init = ($3, []) } }
   | EXCHANGE LPAREN ID RPAREN LCURL comp_handlers RCURL
     { _K := { !_K with exchange = ($3, $6) } }
   | PROPERTIES LCURL props RCURL
@@ -82,9 +82,9 @@ prog :
 
 cond_progs :
   | LCURL prog RCURL
-    { [(mk_cond_prog Always $2)] }
+    { [(mk_cond_prog Always ($2, []))] }
   | WHEN LPAREN when_cond RPAREN LCURL prog RCURL cond_progs
-    { (mk_cond_prog $3 $6) :: $8 }
+    { (mk_cond_prog $3 ($6, [])) :: $8 }
 ;;
 
 cmd :


### PR DESCRIPTION
This is not quite urgent, as I am yet unsure whether it breaks other stuff or not. All tests pass, plus some local tests that do weird things like channel swapping or shadowing.

The code is very ugly, but there are concerns that are easily solved by ugly hacking if I don't want to rewrite the engine from scratch.

Things to remember for the next iteration:

One problem with the ValidExchange/KInvariant constructors is when some universally-quantified variable never appears in the body. Coq will complain that it can't infer its type. It would not be much of a problem if we tracked the (simple) types of such variables, and did typed quantification.

This implies some more type-tracking for variables that arise from the context (handler_vars_non_state), for instance, you want to know the type of variables that appear in the payload of a message.

Here I managed somehow to track the variables that actually appear within the context, and quantify only them, but it seems hairy.
