### PR TITLE
Invoke impl

### DIFF
--- a/reflex/coq/Makefile.bench
+++ b/reflex/coq/Makefile.bench
@@ -12,6 +12,7 @@ all:
 build:
 	$(MAKE) kernel
 	cp -r ../../ml/ .
+	../userprims.sh
 	$(MAKE) extract
 	$(MAKE) -C ml
 

--- a/reflex/coq/Reflex.v
+++ b/reflex/coq/Reflex.v
@@ -2616,7 +2616,7 @@ destruct s as [cs tr e st fds]_eqn; simpl.
 refine (
   let c := eval_base_expr e ce in
   let args := map (eval_base_expr e) argse in
-  f <- invokefd c args (tr ~~~ expand_ktrace tr)
+  f <- invoke_fd c args (tr ~~~ expand_ktrace tr)
    <@> init_invariant s;
 
   let tr := tr ~~~ KInvokeFD c args f :: tr in
@@ -2633,7 +2633,7 @@ destruct s as [cs tr e st fds]_eqn; simpl.
 refine (
   let c := eval_base_expr e ce in
   let args := map (eval_base_expr e) argse in
-  res <- invokestr c args (tr ~~~ expand_ktrace tr)
+  res <- invoke_str c args (tr ~~~ expand_ktrace tr)
    <@> init_invariant s;
 
   let tr := tr ~~~ KInvokeStr c args res :: tr in
@@ -2935,7 +2935,7 @@ refine (
 (*InvokeFD*)
 destruct s as [ [cs tr st] env]_eqn.
 refine (
-  f <- invokefd (eval_hdlr_expr _ _ _ _ ce)
+  f <- invoke_fd (eval_hdlr_expr _ _ _ _ ce)
             (map (eval_hdlr_expr _ _ _ _) argse)
             (tr ~~~ expand_ktrace tr)
     <@> hdlr_invariant cc cm s;
@@ -2954,7 +2954,7 @@ refine (
 (*InvokeStr*)
 destruct s as [ [cs tr st] env]_eqn.
 refine (
-  res <- invokestr (eval_hdlr_expr _ _ _ _ ce)
+  res <- invoke_str (eval_hdlr_expr _ _ _ _ ce)
             (map (eval_hdlr_expr _ _ _ _) argse)
             (tr ~~~ expand_ktrace tr)
     <@> hdlr_invariant cc cm s;

--- a/reflex/coq/bench-quark/UserPrimitives.ml
+++ b/reflex/coq/bench-quark/UserPrimitives.ml
@@ -1,0 +1,53 @@
+let create_socket args =
+  try
+    let socket_desc = (List.nth args 0) in
+    let descs = Str.split (Str.regexp ":") socket_desc in
+    let host = (List.nth descs 0) in
+    let port = int_of_string (List.nth descs 1) in
+    let nfamily = int_of_string (List.nth descs 2) in
+    let family = (if nfamily = 2 then Unix.PF_INET
+                  else if nfamily = 10 then Unix.PF_INET6
+                  else Unix.PF_UNIX) in
+    let nsocktype = int_of_string (List.nth descs 3) in
+    let socktype = (if nsocktype = 1 then Unix.SOCK_STREAM
+                    else if nsocktype = 2 then Unix.SOCK_DGRAM
+                    else if nsocktype = 3 then Unix.SOCK_RAW
+                    else Unix.SOCK_SEQPACKET) in
+    let socket = Unix.socket family socktype 0 in
+    let ipaddr = (Unix.gethostbyname host).Unix.h_addr_list.(0) in
+    let portaddr = Unix.ADDR_INET (ipaddr, port) in
+    Unix.connect socket portaddr;
+    socket
+  with
+    _ -> fd_of_int 0
+
+let dom_ok args =
+  let is_suffix str suffix = 
+    (Str.string_match (Str.regexp (String.concat "" (".*"::suffix::[]))) str 0) in
+  let socket_desc = (List.nth args 0) in
+  let domain = (List.nth args 1) in
+  let descs = Str.split (Str.regexp ":") socket_desc in
+  let host = (List.nth descs 0) in
+  let whitelist = [ ("google.com", ["gstatic.com"]);
+                    ("facebook.com", ["fbcdn.net"]);
+                    ("youtube.com", ["ytimg.com"]);
+                    ("yahoo.com", ["yimg.com"]);
+                    ("wikipedia.org", ["wikimedia.org"]);
+                    ("twitter.com", ["twimg.com"]);
+                    ("blogger.com", ["google.com"; "blogspot.com"; "gstatic.com";
+                                     "googleusercontent.com"]);
+                    ("ebay.com", ["ebaystatic.com"; "ebayimg.com"; "ebayrtm.com";
+                                  "ebay-stories.com" ]) ] in
+   if (is_suffix host domain) then ""
+   else if (List.fold_left (fun acc (dmn, whtlst) -> acc ||
+                            if (is_suffix domain dmn)
+                            then (List.fold_left (fun a whtdmn -> a || (is_suffix host whtdmn)) false whtlst)
+                            else false) false whitelist) then ""
+   else "error"
+
+let _INVOKE_FD_MAP : (string * (string list -> Unix.file_descr)) list =
+  [("create_socket", create_socket)]
+
+let _INVOKE_STR_MAP : (string * (string list -> string)) list =
+  [("dom_ok", dom_ok)]
+

--- a/reflex/coq/bench-quark/UserPrimitives.ml
+++ b/reflex/coq/bench-quark/UserPrimitives.ml
@@ -34,10 +34,7 @@ let dom_ok args =
                     ("yahoo.com", ["yimg.com"]);
                     ("wikipedia.org", ["wikimedia.org"]);
                     ("twitter.com", ["twimg.com"]);
-                    ("blogger.com", ["google.com"; "blogspot.com"; "gstatic.com";
-                                     "googleusercontent.com"]);
-                    ("ebay.com", ["ebaystatic.com"; "ebayimg.com"; "ebayrtm.com";
-                                  "ebay-stories.com" ]) ] in
+                    ("ebay.com", ["ebaystatic.com"])] in
    if (is_suffix host domain) then ""
    else if (List.fold_left (fun acc (dmn, whtlst) -> acc ||
                             if (is_suffix domain dmn)

--- a/reflex/coq/bench-quark/test/quark/tab/tab.py
+++ b/reflex/coq/bench-quark/test/quark/tab/tab.py
@@ -107,6 +107,14 @@ class Tab:
     shm_obj = None
     sem_obj = None
     message_handler = None
+    whitelist = {
+        "google.com":"gstatic.com",
+        "facebook.com":"fbcdn.net",
+        "youtube.com":"ytimg.com",
+        "yahoo.com":"yimg.com",
+        "wikipedia.org":"wikimedia.org",
+        "twitter.com":"twimg.com",
+        "ebay.com":"ebaystatic.com"}
 
     def get_origin(self, uri) :
         p1 = urlparse.urlparse(uri)
@@ -173,12 +181,16 @@ class Tab:
                     # if it's not the main frame, Webkit will use a
                     # Wget message.
                     pass
+
         #print "something different.."
         # let's disable socket creation temporarily
-        #if self.is_tab_sub_origin(uri) :
-        # if this request is within the tab's origin, it's allowed for socket conneciton
-        # tlog(uri + " is within the tab origin : " + self.tab_origin)
-        #return
+        if self.is_tab_sub_origin(uri) :
+            # if this request is within the tab's origin, it's allowed for socket conneciton
+            # tlog(uri + " is within the tab origin : " + self.tab_origin)
+            return
+
+        if self.tab_origin in self.whitelist :
+            if self.is_sub_origin(self.whitelist[self.tab_origin], str(uri)): return
 
         self.message_handler.send([message.URLRequest, uri])
         

--- a/reflex/coq/userprims.sh
+++ b/reflex/coq/userprims.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# insert user-defined primitives into the Reflex runtime module
+# if a benchmark has UserPrimitives.ml file.
+
+TEMPLATE=./ml/primitives/ReflexImpl.ml
+if [ -a UserPrimitives.ml ];
+then
+    start=`grep -n "(\* BEGIN:UserPrimitives \*)" $TEMPLATE | cut -f1 -d:`
+    end=`grep -n "(\* END:UserPrimitives \*)" $TEMPLATE | cut -f1 -d:`
+    lineno=`wc $TEMPLATE | cut -f2 -d' '`
+    tempfile=`mktemp`
+    head -n $start $TEMPLATE > tempfile
+    cat UserPrimitives.ml >> tempfile
+    tail -n $(($lineno-$(($end-1)))) $TEMPLATE >> tempfile
+    mv tempfile $TEMPLATE
+fi

--- a/reflex/ml/Makefile
+++ b/reflex/ml/Makefile
@@ -8,6 +8,7 @@ SOBJS := $(patsubst %,-dllib\ -l%,$(SOBJS))
 FLAGS := \
 	-verbose 2 \
 	-lib unix \
+	-lib str \
 	-cflags -g \
 	-lflags -g,-I,$(SODIR),$(SOBJS),-dllpath,$(SODIR) \
 	-no-links

--- a/reflex/ml/primitives/ReflexImpl.ml
+++ b/reflex/ml/primitives/ReflexImpl.ml
@@ -221,19 +221,25 @@ let send_fd cfd x _ =
         (int_of_fd fd) (int_of_fd x));
   ()
 
-let _INVOKE_FD_MAP : (string * (string list -> int)) list =
+(* BEGIN:UserPrimitives *)
+let _INVOKE_FD_MAP : (string * (string list -> Unix.file_descr)) list =
   []
-
-let invoke_fd prog args _ =
-  let fd = (List.assoc prog _INVOKE_FD_MAP) args in
-  log (Printf.sprintf "invoke_fd : %s [%s] -> %s"
-    prog (String.concat ", " args) fd);
-  cfd_of_fd fd
 
 let _INVOKE_STR_MAP : (string * (string list -> string)) list =
   []
+(* END:UserPrimitives *)
 
-let invoke_str prog args _ =
+let invoke_fd cprog cargs _ =
+  let prog = string_of_str cprog in
+  let args = List.map string_of_str cargs in
+  let fd = (List.assoc prog _INVOKE_FD_MAP) args in
+  log (Printf.sprintf "invoke_fd : %s [%s] -> %d"
+    prog (String.concat ", " args) (int_of_fd fd));
+  cfd_of_fd fd
+
+let invoke_str cprog cargs _ =
+  let prog = string_of_str cprog in
+  let args = List.map string_of_str cargs in
   let s = (List.assoc prog _INVOKE_STR_MAP) args in
   log (Printf.sprintf "invoke_str : %s [%s] -> %s"
     prog (String.concat ", " args) s);


### PR DESCRIPTION
Reflex Quark works under primitives to create sockets/whitelisting

invoke_fd/str gets a string that mapped to a user-defined OCaml function in bench-quark/UserPrimitives.ml and executes it. For now, these are only used for Quark to do whitelist checking/direct socket creation in the Reflex Kernel.

@dricketts 
